### PR TITLE
fix: call method nil.

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -227,7 +227,7 @@ func (r *runner) isCloseCall(ccall ssa.Instruction) bool {
 			return true
 		}
 	case *ssa.Call:
-		if ccall.Call.Method.Name() == r.closeMthd.Name() {
+		if ccall.Call.Method != nil && ccall.Call.Method.Name() == r.closeMthd.Name() {
 			return true
 		}
 	case *ssa.ChangeInterface:

--- a/passes/bodyclose/testdata/src/a/issue4.go
+++ b/passes/bodyclose/testdata/src/a/issue4.go
@@ -1,0 +1,20 @@
+package a
+
+import (
+	"io"
+	"net/http"
+)
+
+func issue4_1() {
+	resp, _ := http.Get("https://example.com") // want "response body must be closed"
+
+	foo(resp.Body)
+}
+
+func foo(r io.ReadCloser) {}
+
+func issue4_2() {
+	resp, _ := http.Get("https://example.com") // want "response body must be closed"
+
+	_ = http.MaxBytesReader(nil, resp.Body, 1024)
+}


### PR DESCRIPTION
The following sample panic:

```go
func issue() {
	resp, _ := http.Get("https://example.com")
	reader := http.MaxBytesReader(nil, resp.Body, 1024*1024)
	fmt.Println(reader)
}
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x649024]

goroutine 1183 [running]:
go/types.(*object).Name(...)
	/home/ldez/.gvm/gos/go1.12.5/src/go/types/object.go:134
github.com/timakin/bodyclose/passes/bodyclose.(*runner).isCloseCall(0xc0000d0700, 0x804400, 0xc00874e280, 0xc001a28360)
	/home/ldez/sources/go/src/github.com/timakin/bodyclose/passes/bodyclose/bodyclose.go:230 +0x234
github.com/timakin/bodyclose/passes/bodyclose.(*runner).isopen(0xc0000d0700, 0xc0091909a0, 0x0, 0xc005e44400)
	/home/ldez/sources/go/src/github.com/timakin/bodyclose/passes/bodyclose/bodyclose.go:175 +0x2e9
github.com/timakin/bodyclose/passes/bodyclose.(*runner).run(0xc0000d0700, 0xc004912750, 0x10, 0x734b80, 0x4519bc3afd235501, 0xc008049190)
	/home/ldez/sources/go/src/github.com/timakin/bodyclose/passes/bodyclose/bodyclose.go:100 +0x641
golang.org/x/tools/go/analysis/internal/checker.(*action).execOnce(0xc005e1e3c0)
	/home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.0.0-20190322203728-c1a832b0ad89/go/analysis/internal/checker/checker.go:513 +0x68a
sync.(*Once).Do(0xc005e1e3c0, 0xc000047790)
	/home/ldez/.gvm/gos/go1.12.5/src/sync/once.go:44 +0xb3
golang.org/x/tools/go/analysis/internal/checker.(*action).exec(0xc005e1e3c0)
	/home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.0.0-20190322203728-c1a832b0ad89/go/analysis/internal/checker/checker.go:434 +0x50
golang.org/x/tools/go/analysis/internal/checker.execAll.func1(0xc005e1e3c0)
	/home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.0.0-20190322203728-c1a832b0ad89/go/analysis/internal/checker/checker.go:422 +0x34
created by golang.org/x/tools/go/analysis/internal/checker.execAll
	/home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.0.0-20190322203728-c1a832b0ad89/go/analysis/internal/checker/checker.go:428 +0x11b
```

another sample:

```go
func issue5() {
	resp, _ := http.Get("https://example.com")
	foo(resp.Body)
}

func foo(r io.ReadCloser) {}
```

I'm not sure about the fix.
