### PR TITLE
fix #8, fix #16: fix parallel writes to runner

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -38,7 +38,9 @@ type runner struct {
 	skipFile  map[*ast.File]bool
 }
 
-func (r *runner) run(pass *analysis.Pass) (interface{}, error) {
+// run executes an analysis for the pass. The receiver is passed
+// by value because this func is called in parallel for different passes.
+func (r runner) run(pass *analysis.Pass) (interface{}, error) {
 	r.pass = pass
 	funcs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
 


### PR DESCRIPTION
runner.run is called in parallel by go/analysis
therefore we need to handle parallel writes to the runner