### PR TITLE
fix: panic.

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -325,7 +325,7 @@ func (r *runner) calledInFunc(f *ssa.Function, called bool) bool {
 								}
 								for _, vref := range vrefs {
 									if c, ok := vref.(*ssa.Call); ok {
-										if c.Call.Method.Name() == closeMethod {
+										if c.Call.Method != nil && c.Call.Method.Name() == closeMethod {
 											return !called
 										}
 									}


### PR DESCRIPTION

https://github.com/golangci/golangci-lint/issues/733

```
WARN [linters context] Panic: bodyclose: package "phttp" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference: goroutine 47307 [running]:
runtime/debug.Stack(0xf57075, 0x3c, 0xc00167d8b8)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1(0xc034cff740)
        /Users/denis/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:404 +0x1af
panic(0xd9a0e0, 0x1720290)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
go/types.(*object).Name(...)
        /usr/local/go/src/go/types/object.go:133
github.com/timakin/bodyclose/passes/bodyclose.(*runner).calledInFunc(0xc00167dc78, 0xc0b624d7c0, 0xc0b6512800, 0x10ae3a0)
        /Users/denis/go/src/github.com/golangci/golangci-lint/vendor/github.com/timakin/bodyclose/passes/bodyclose/bodyclose.go:328 +0x284
github.com/timakin/bodyclose/passes/bodyclose.(*runner).isopen(0xc00167dc78, 0xc0b6476580, 0x14, 0x0)
        /Users/denis/go/src/github.com/golangci/golangci-lint/vendor/github.com/timakin/bodyclose/passes/bodyclose/bodyclose.go:148 +0x555
github.com/timakin/bodyclose/passes/bodyclose.runner.run(0xc0a41bfc20, 0x10b9cc0, 0xc020a70910, 0xc0b6fc58e0, 0x10b9d60, 0xc020aea690, 0xc003d10c80, 0xc0b6f71a10, 0xc0a41bfc20, 0xe41140933e432942, ...)
        /Users/denis/go/src/github.com/golangci/golangci-lint/vendor/github.com/timakin/bodyclose/passes/bodyclose/bodyclose.go:102 +0x589
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc034cff740)
        /Users/denis/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:495 +0x87a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc034cff740)
        /Users/denis/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:407 +0x5b
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func3(0xc09f24a800, 0xc034cff740)
        /Users/denis/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:961 +0x69
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
        /Users/denis/go/src/github.com/golangci/golangci-lint/pkg/g
```