### PR TITLE
Fix: #27, when function returns io.Closer/io.ReadCloser

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -250,6 +250,20 @@ func (r *runner) isCloseCall(ccall ssa.Instruction) bool {
 						}
 					}
 				}
+
+				if returnOp, ok := cs.(*ssa.Return); ok {
+					for _, resultValue := range returnOp.Results {
+						if resultValue.Type().String() == "io.Closer" {
+							return true
+						}
+					}
+				}
+			}
+		}
+	case *ssa.Return:
+		for _, resultValue := range ccall.Results {
+			if resultValue.Type().String() == "io.ReadCloser" {
+				return true
 			}
 		}
 	}

--- a/passes/bodyclose/testdata/src/a/issue27.go
+++ b/passes/bodyclose/testdata/src/a/issue27.go
@@ -1,0 +1,30 @@
+package a
+
+import (
+	"io"
+	"net/http"
+)
+
+func issue27_1(url string) (io.ReadCloser, error) { // body should be closed by User
+	r, err := http.DefaultClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return r.Body, nil
+}
+
+func issue27_2(url string) (io.Closer, error) { // body should be closed by User
+	r, err := http.DefaultClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return r.Body, nil
+}
+
+func issue27_3(url string) (io.Closer, error) { // body should be closed by User
+	r, err := http.DefaultClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return r.Body, nil
+}


### PR DESCRIPTION
#27 

- Adds test
- Adds check to `isCloseCall` function