### PR TITLE
Do not filter out files without net/http

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -80,11 +80,6 @@ func (r runner) run(pass *analysis.Pass) (interface{}, error) {
 
 	r.skipFile = map[*ast.File]bool{}
 	for _, f := range funcs {
-		if r.noImportedNetHTTP(f) {
-			// skip this
-			continue
-		}
-
 		// skip if the function is just referenced
 		var isreffunc bool
 		for i := 0; i < f.Signature.Results().Len(); i++ {

--- a/passes/bodyclose/testdata/src/a/helper.go
+++ b/passes/bodyclose/testdata/src/a/helper.go
@@ -1,0 +1,7 @@
+package a
+
+import "net/http"
+
+func doRequestWithoutClose() (*http.Response, error) {
+	return http.Get("https://example.com")
+}

--- a/passes/bodyclose/testdata/src/a/no_import.go
+++ b/passes/bodyclose/testdata/src/a/no_import.go
@@ -1,0 +1,5 @@
+package a
+
+func doRequestInHelperFunc() {
+	_, _ = doRequestWithoutClose() // want "response body must be closed"
+}


### PR DESCRIPTION
Seems like we should not filter out files without `net/http` import. Here's the case:

**helper.go**:
```go
package a

import "net/http"

func doRequest(string url) (*http.Response, error) {
    return http.Get(url)
}
```
**main.go**:
```go
package a

func doStuff() {
    resp, err := doRequest("https://example.com/")
    // ...
}
```
`resp.Body` remains opened but since `main.go` doesn't have `net/http` import analyzer skips it. 

Same happens when you use something like `ctxhttp`.