### PR TITLE
Handle more cases — round 1

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -147,8 +147,14 @@ func (r *runner) isopen(b *ssa.BasicBlock, i int) bool {
 			case *ssa.Call: // Indirect function call
 				if f, ok := resRef.Call.Value.(*ssa.Function); ok {
 					for _, b := range f.Blocks {
-						for i := range b.Instrs {
-							return r.isopen(b, i)
+						for i, bi := range b.Instrs {
+							if r.isCloseCall(bi) {
+								return false
+							}
+
+							if r.isopen(b, i) {
+								return true
+							}
 						}
 					}
 				}

--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -144,8 +144,17 @@ func (r *runner) isopen(b *ssa.BasicBlock, i int) bool {
 					}
 
 				}
-			case *ssa.Call: // Indirect function call
-				if f, ok := resRef.Call.Value.(*ssa.Function); ok {
+			case *ssa.Call, *ssa.Defer: // Indirect function call
+				// Hacky way to extract CommonCall
+				var call ssa.CallCommon
+				switch rr := resRef.(type) {
+				case *ssa.Call:
+					call = rr.Call
+				case *ssa.Defer:
+					call = rr.Call
+				}
+
+				if f, ok := call.Value.(*ssa.Function); ok {
 					for _, b := range f.Blocks {
 						for i, bi := range b.Instrs {
 							if r.isCloseCall(bi) {

--- a/passes/bodyclose/testdata/src/a/closebycall.go
+++ b/passes/bodyclose/testdata/src/a/closebycall.go
@@ -14,9 +14,24 @@ func closeByCall() {
 	process(res)
 }
 
+func closeByCallDeferOK() {
+	res, err := http.Get("http://example.com/") // OK
+	if err != nil {
+		panic(err)
+	}
+
+	defer close(res)
+}
+
 func process(res *http.Response) {
 	_, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}
+}
+
+func close(res *http.Response) {
+	process(res)
+
+	defer res.Body.Close()
 }

--- a/passes/bodyclose/testdata/src/a/closebycall.go
+++ b/passes/bodyclose/testdata/src/a/closebycall.go
@@ -1,0 +1,22 @@
+package a
+
+import (
+	"io"
+	"net/http"
+)
+
+func closeByCall() {
+	res, err := http.Get("http://example.com/") // want "response body must be closed"
+	if err != nil {
+		panic(err)
+	}
+
+	process(res)
+}
+
+func process(res *http.Response) {
+	_, err := io.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
We experienced a crash of one of our production services a couple of weeks ago due to an un-closed HTTP response body.
This change covers more cases which would have detected the problem and prevented the crash.

![image](https://user-images.githubusercontent.com/5585491/185617569-aa1b2c71-a080-4843-b45e-392247fe9f0f.png)
