### PR TITLE
Update Go version and CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   default:
     working_directory: /go/src/github.com/timakin/bodyclose
     docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.22
     environment:
     - APP_NAME: bodyclose
     - GO111MODULE: "on"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/timakin/bodyclose
 
-go 1.12
+go 1.22
 
 require (
 	github.com/gostaticanalysis/analysisutil v0.7.1

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+//go:build !go1.12
 // +build !go1.12
 
 package main

--- a/main_go112.go
+++ b/main_go112.go
@@ -1,3 +1,4 @@
+//go:build go1.12
 // +build go1.12
 
 package main


### PR DESCRIPTION
## Summary
- set module to go 1.22
- use Go 1.22 image in CircleCI
- add go:build tags to main files for compatibility

## Testing
- `go test ./...` *(fails: lookup proxy.golang.org: no such host)*