### PR TITLE
Add optional HTTP response body consumption checking with -check-consumption flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ internal/httpclient/httpclient.go:13:13: response body must be closed
 You can enable additional checks with the `-check-consumption` flag to also verify that response bodies are consumed:
 
 ```bash
-$ go vet -vettool=$(which bodyclose) -bodyclose.check-consumption github.com/timakin/go_api/...
+$ go vet -vettool=$(which bodyclose) -check-consumption github.com/timakin/go_api/...
 ```
 
 #### Supported Consumption Patterns

--- a/main_go112.go
+++ b/main_go112.go
@@ -4,17 +4,7 @@ package main
 
 import (
 	"github.com/timakin/bodyclose/passes/bodyclose"
-	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/analysis/unitchecker"
+	"golang.org/x/tools/go/analysis/singlechecker"
 )
 
-// Analyzers returns analyzers of bodyclose.
-func analyzers() []*analysis.Analyzer {
-	return []*analysis.Analyzer{
-		bodyclose.Analyzer,
-	}
-}
-
-func main() {
-	unitchecker.Main(analyzers()...)
-}
+func main() { singlechecker.Main(bodyclose.Analyzer) }

--- a/passes/bodyclose/consumption_test.go
+++ b/passes/bodyclose/consumption_test.go
@@ -1,0 +1,17 @@
+package bodyclose_test
+
+import (
+	"testing"
+
+	"github.com/timakin/bodyclose/passes/bodyclose"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestConsumption(t *testing.T) {
+	// Create analyzer with consumption flag enabled
+	analyzer := *bodyclose.Analyzer // Copy the analyzer
+	analyzer.Flags.Set("check-consumption", "true")
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, &analyzer, "consumption")
+}

--- a/passes/bodyclose/testdata/src/consumption/consumption.go
+++ b/passes/bodyclose/testdata/src/consumption/consumption.go
@@ -1,0 +1,215 @@
+package consumption
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// Test cases for consumption checking - documents exactly what patterns are supported
+
+// ✅ SUPPORTED PATTERNS (should pass - no errors)
+
+// Pattern 1: io.Copy with io.Discard
+func consumedWithIOCopy() {
+	resp, err := http.Get("http://example.com/") // OK - io.Copy detected
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+}
+
+// Pattern 2: io.ReadAll
+func consumedWithIOReadAll() {
+	resp, err := http.Get("http://example.com/") // OK - io.ReadAll detected
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+}
+
+// Pattern 3: ioutil.ReadAll (legacy)
+func consumedWithIoutilReadAll() {
+	resp, err := http.Get("http://example.com/") // OK - ioutil.ReadAll detected
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = ioutil.ReadAll(resp.Body)
+}
+
+// Pattern 4: json.NewDecoder
+func consumedWithJSONDecoder() {
+	resp, err := http.Get("http://example.com/") // OK - json.NewDecoder detected
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	var data map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&data)
+}
+
+// Pattern 5: bufio.NewScanner
+func consumedWithBufioScanner() {
+	resp, err := http.Get("http://example.com/") // OK - bufio.NewScanner detected
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		_ = scanner.Text()
+	}
+}
+
+// Pattern 6: bufio.NewReader
+func consumedWithBufioReader() {
+	resp, err := http.Get("http://example.com/") // OK - bufio.NewReader detected
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	_, _, _ = reader.ReadLine()
+}
+
+// Pattern 7: Helper function with known consumption
+func consumedInHelper() {
+	resp, err := http.Get("http://example.com/") // OK - helper uses io.Copy
+	if err != nil {
+		return
+	}
+	defer drainAndClose(resp)
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		io.Copy(io.Discard, resp.Body) // This io.Copy is detected
+		resp.Body.Close()
+	}
+}
+
+// ⚠️  FALSE POSITIVES (these will incorrectly show errors)
+
+// These patterns actually DO consume the body correctly, but are not detected
+// by the current implementation. In real code, use //nolint:bodyclose to suppress.
+
+func falsePositiveDirectRead() {
+	resp, err := http.Get("http://example.com/") // want "response body must be closed and consumed"
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	// This DOES consume the body, but analyzer doesn't detect it
+	buf := make([]byte, 1024)
+	resp.Body.Read(buf) // Actually consumes the body
+}
+
+func falsePositiveCustomFunction() {
+	resp, err := http.Get("http://example.com/") // want "response body must be closed and consumed"
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	// This DOES consume the body, but analyzer doesn't detect it
+	customProcess(resp.Body) // Actually consumes the body
+}
+
+func customProcess(r io.Reader) {
+	// Custom processing logic
+	buf := make([]byte, 1024)
+	for {
+		n, err := r.Read(buf)
+		if err != nil || n == 0 {
+			break
+		}
+	}
+}
+
+// ❌ REAL PROBLEMS (correctly detected errors)
+
+// These cases should show errors because the body is NOT properly consumed
+
+func actuallyNotConsumed() {
+	resp, err := http.Get("http://example.com/") // want "response body must be closed and consumed"
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	// Body is closed but NOT consumed - this is a real problem
+}
+
+func neitherClosedNorConsumed() {
+	resp, err := http.Get("http://example.com/") // want "response body must be closed and consumed"
+	if err != nil {
+		return
+	}
+	_ = resp
+	// Body is neither closed nor consumed - this is a real problem
+}
+
+// RequestBody/ResponseBody distinction test cases
+func requestBodyReadShouldNotInterfere(w http.ResponseWriter, r *http.Request) {
+	// Read incoming request body
+	_, _ = io.ReadAll(r.Body) // This is REQUEST body consumption
+
+	// Make outgoing request - response body should still be detected as unconsumed
+	resp, err := http.Get("http://example.com/") // want "response body must be closed and consumed"
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	// Response body is NOT consumed - should be detected despite request body read
+}
+
+func localRequestBodyDistinction() {
+	// Create local request and read its body
+	req, _ := http.NewRequest("POST", "http://example.com", nil)
+	_, _ = io.ReadAll(req.Body) // This is REQUEST body consumption
+
+	// Make HTTP request - response body not consumed, should be detected
+	resp, _ := http.Get("http://example.com") // want "response body must be closed and consumed"
+	defer resp.Body.Close()
+}
+
+func functionParameterRequestBody(req *http.Request) {
+	// Read request body from function parameter
+	_, _ = io.ReadAll(req.Body) // This is REQUEST body consumption
+
+	// Make HTTP request - response body not consumed, should be detected
+	resp, _ := http.Get("http://example.com") // want "response body must be closed and consumed"
+	defer resp.Body.Close()
+}
+
+func properResponseBodyConsumptionWithRequestBody(w http.ResponseWriter, r *http.Request) {
+	// Read request body
+	_, _ = io.ReadAll(r.Body) // This is REQUEST body consumption
+
+	// Make HTTP request - response body properly consumed, should pass
+	resp, _ := http.Get("http://example.com") // OK - response body properly consumed
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body) // This is RESPONSE body consumption
+}
+
+// closeBeforeConsume is commented out because current implementation
+// doesn't detect execution order (documented limitation)
+//
+// func closeBeforeConsume() {
+// 	resp, err := http.Get("http://example.com/")
+// 	if err != nil {
+// 		return
+// 	}
+// 	resp.Body.Close() // Closed first
+// 	io.ReadAll(resp.Body) // Then trying to consume - this would fail at runtime
+// 	// NOTE: Current implementation doesn't detect execution order,
+// 	// but this would fail at runtime anyway
+// }


### PR DESCRIPTION
Thank you for this excellent analysis tool!

## Summary

  As mentioned in issue #43, it would be helpful to check not only if `resp.Body.Close()` is called, but also whether the response body is actually consumed. This PR implements an optional `-check-consumption` flag to provide this
  functionality.

## Motivation

  While the current tool ensures bodies are closed, checking consumption is also valuable for:
  - Proper connection reuse in HTTP clients
  - Preventing potential resource leaks
  - Following Go HTTP client best practices

## Implementation

### Key Features
  - ✅ **Fully backward compatible** - existing behavior unchanged without the flag
  - ✅ **Opt-in functionality** - only active with `-check-consumption` flag
  - ✅ **Comprehensive detection** for common consumption patterns

### Supported Consumption Patterns
  - `io.Copy(io.Discard, resp.Body)`
  - `io.ReadAll(resp.Body)` / `ioutil.ReadAll(resp.Body)`
  - `json.NewDecoder(resp.Body)`
  - `bufio.NewScanner(resp.Body)` / `bufio.NewReader(resp.Body)`

  ## Documentation

  - **False positive cases documented** with clear examples and workarounds
  - **README updated** with usage examples and limitations

## Known Limitations

  Since detecting all consumption patterns is challenging, some false positives may occur:
  - Custom consumption patterns may not be detected
  - Execution order checking is not implemented
  - Workaround: Use `//nolint:bodyclose` for false positives

  All limitations are documented in the README with examples.

## Compatibility

  No impact on existing functionality - the new feature is completely opt-in via the `-check-consumption` flag.

---

  **Note**: This pull request includes commits generated with Claude Code assistance, but I have carefully reviewed and guided the implementation throughout the development process.

  This enhancement helps developers write more robust HTTP client code while maintaining the tool's existing simplicity and reliability.