### PR TITLE
Fix false positive in getReqCall: use types.Identical instead of string matching

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/types"
 	"strconv"
-	"strings"
 
 	"github.com/gostaticanalysis/analysisutil"
 	"golang.org/x/tools/go/analysis"
@@ -270,13 +269,22 @@ func (r *runner) getReqCall(instr ssa.Instruction) (*ssa.Call, bool) {
 	if !ok {
 		return nil, false
 	}
-	callType := call.Type().String()
-	if !strings.Contains(callType, r.resTyp.String()) ||
-		strings.Contains(callType, "net/http.ResponseController") {
-		return nil, false
+
+	callType := call.Type()
+
+	if types.Identical(callType, r.resTyp) {
+		return call, true
 	}
 
-	return call, true
+	if tuple, ok := callType.(*types.Tuple); ok {
+		for i := 0; i < tuple.Len(); i++ {
+			if types.Identical(tuple.At(i).Type(), r.resTyp) {
+				return call, true
+			}
+		}
+	}
+
+	return nil, false
 }
 
 func (r *runner) getResVal(instr ssa.Instruction) (ssa.Value, bool) {

--- a/passes/bodyclose/testdata/src/a/function_type.go
+++ b/passes/bodyclose/testdata/src/a/function_type.go
@@ -1,0 +1,23 @@
+package a
+
+import (
+	"context"
+	"net/http"
+)
+
+// Simulates a retryablehttp.CheckRetry policy builder.
+// Returns func(context.Context, *http.Response, error) (bool, error).
+// call.Type() is *types.Signature — not *http.Response or a tuple containing it.
+func NewRetryPolicy(isKnown func(*http.Response, []byte) bool) func(context.Context, *http.Response, error) (bool, error) {
+	return func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		return false, nil
+	}
+}
+
+func useFunctionTypes() {
+	_ = NewRetryPolicy(nil) // OK - returns a function type, not *http.Response
+
+	// Real http call should still be detected
+	resp, _ := http.Get("http://example.com/") // want "response body must be closed"
+	_ = resp
+}


### PR DESCRIPTION
Closes #71

## Problem

`getReqCall` currently uses `strings.Contains(call.Type().String(), "*http.Response")` to identify calls that return `*http.Response`. This matches any call whose return type's string representation contains `*http.Response`, including functions that return **function types with `*http.Response` as a parameter** (e.g. `func(*http.Response) error`).

This causes false positives with libraries like `carlmjohnson/requests` (`ToBytesBuffer` returns `func(*http.Response) error`) and `hashicorp/go-retryablehttp` (`CheckRetry` is `func(context.Context, *http.Response, error) (bool, error)`).

## Solution

Replace `strings.Contains` with `types.Identical` to compare the return type precisely:

- Single return value: check if it is exactly `*http.Response`
- Multiple return values (`*types.Tuple`): check each element

This also makes the `ResponseController` exclusion hack unnecessary, as `types.Identical` naturally skips it.

If there was an intentional reason for using string-based matching, my apologies — I may have missed the context.

## Test

Added `testdata/src/a/function_type.go` to verify that calls returning function types containing `*http.Response` as a parameter are not flagged.
